### PR TITLE
chore(lfs,deps): remove stale LFS entries, add artifact LFS rules, ignore breaking dep bumps

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
-contracts/reports/formal/scribble/scribble.json filter=lfs diff=lfs merge=lfs -text
+# Large generated audit reports — store as LFS to avoid GitHub 100MB limit
+artifacts/todo-audit-report*.md filter=lfs diff=lfs merge=lfs -text
+
 infra/opstack/bin/op-deployer-0.5.2-linux-amd64/op-deployer filter=lfs diff=lfs merge=lfs -text
 infra/opstack/bin/op-deployer-0.6.0-rc.2-linux-amd64/op-deployer filter=lfs diff=lfs merge=lfs -text
 infra/opstack/bin/op-deployer-x86 filter=lfs diff=lfs merge=lfs -text
 infra/opstack/bin/op-deployer-local filter=lfs diff=lfs merge=lfs -text
-.gomodcache/cache/download/golang.org/toolchain/@v/v0.0.1-go1.24.10.linux-arm64.zip filter=lfs diff=lfs merge=lfs -text
-.gomodcache/github.com/ferranbt/fastssz@v0.1.4/spectests/fixtures/beacon_state_bellatrix.ssz filter=lfs diff=lfs merge=lfs -text

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,12 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    ignore:
+      # tailwindcss v4 is a major migration requiring @tailwindcss/postcss and CSS changes.
+      # Pin to v3.x until a dedicated migration is done.
+      - dependency-name: "tailwindcss"
+        update-types:
+          - "version-update:semver-major"
     groups:
       npm-root:
         patterns:
@@ -54,6 +60,17 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    ignore:
+      # Repo is pinned to Hardhat 2.x. Block Hardhat v3 ecosystem major bumps.
+      - dependency-name: "hardhat"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@nomicfoundation/hardhat-*"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@nomiclabs/*"
+        update-types:
+          - "version-update:semver-major"
     groups:
       npm-contracts:
         patterns:


### PR DESCRIPTION
## Summary

### `.gitattributes` changes
- **Remove** 3 stale LFS tracking entries that reference paths no longer in the repo:
  - `contracts/reports/formal/scribble/scribble.json`
  - `.gomodcache/cache/download/golang.org/toolchain/@v/v0.0.1-go1.24.10.linux-arm64.zip`
  - `.gomodcache/github.com/ferranbt/fastssz@v0.1.4/spectests/fixtures/beacon_state_bellatrix.ssz`
- **Add** LFS tracking for `artifacts/todo-audit-report*.md` — these files exceed GitHub's 100MB file-size limit and must be stored as LFS pointers rather than regular git objects.

Closes #4.

### `.github/dependabot.yml` changes
- **`npm-root` group**: ignore `tailwindcss` major version bumps. TailwindCSS v4 requires a dedicated migration (`@tailwindcss/postcss`, updated PostCSS config, possible CSS directive changes in `apps/web`). Prevents re-creation of closed PR #5.
- **`npm-contracts` group**: ignore `hardhat`, `@nomicfoundation/hardhat-*`, and `@nomiclabs/*` major version bumps. Repo is pinned to Hardhat 2.x (migrated in PR #8); upgrading to v3.x plugins is deliberately deferred. Prevents re-creation of closed PRs #6 and #9.