### PR TITLE
fix(ci): fix 4 workflow failures

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+      run: docker build . --file apps/api/Dockerfile --tag my-image-name:$(date +%s)

--- a/.github/workflows/ghostvm-ai-bundle-e2e.yml
+++ b/.github/workflows/ghostvm-ai-bundle-e2e.yml
@@ -55,12 +55,12 @@ jobs:
           fi
           echo "$BUNDLE_JSON" > /tmp/ghostvm-ai-bundle.json
           BUNDLE_ID=$(python3 - <<'PY'
-import json
-from pathlib import Path
-payload = json.loads(Path('/tmp/ghostvm-ai-bundle.json').read_text())
-print(payload['bundle_id'])
-PY
-)
+          import json
+          from pathlib import Path
+          payload = json.loads(Path('/tmp/ghostvm-ai-bundle.json').read_text())
+          print(payload['bundle_id'])
+          PY
+          )
           echo "bundle_id=$BUNDLE_ID" >> "$GITHUB_OUTPUT"
           cp -r "/tmp/ghostvm-ai-bundles/$BUNDLE_ID" "/tmp/$BUNDLE_ID"
 

--- a/.github/workflows/ghostvm-ai-workflow-lint.yml
+++ b/.github/workflows/ghostvm-ai-workflow-lint.yml
@@ -25,14 +25,14 @@ jobs:
       - name: Validate YAML syntax
         run: |
           python - <<'PY'
-from pathlib import Path
-import yaml
-
-targets = list(Path('.github/workflows').glob('*.yml')) + list(Path('.github/actions').rglob('action.yml'))
-for target in targets:
-    yaml.safe_load(target.read_text(encoding='utf-8'))
-print(f"validated_yaml_files={len(targets)}")
-PY
+          from pathlib import Path
+          import yaml
+          targets = list(Path('.github/workflows').glob('*.yml')) + \
+            list(Path('.github/actions').rglob('action.yml') if Path('.github/actions').exists() else [])
+          for target in targets:
+            yaml.safe_load(target.read_text(encoding='utf-8'))
+          print(f"validated_yaml_files={len(targets)}")
+          PY
 
       - name: Run actionlint
         uses: rhysd/actionlint@v1

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -61,6 +61,7 @@ jobs:
           #
           # You may remove this line if you want to manage the configuration yourself.
           static_site_generator: next
+          enablement: true
       - name: Restore cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/supply-chain-security.yml
+++ b/.github/workflows/supply-chain-security.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install Trivy
         run: |
           set -euo pipefail
-          TRIVY_VERSION="0.69.0"
+          TRIVY_VERSION="0.69.1"
           curl -sSfL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
             | tar -xz trivy
           sudo mv trivy /usr/local/bin/trivy


### PR DESCRIPTION
## Fixes 4 failing GitHub Actions workflows\n\n### Root causes & fixes\n\n| Workflow | Failure | Fix |\n|----------|---------|-----|\n| `ghostvm-ai-workflow-lint.yml` | Python heredoc content at column 0 — YAML parser treats unindented lines as new keys → parse error | Indent all heredoc lines to match `run: \|` block indent level |\n| `ghostvm-ai-bundle-e2e.yml` | Same YAML heredoc indentation issue | Same fix |\n| `supply-chain-security.yml` | Trivy `0.69.0` returns HTTP 404 (release doesn't exist) | Bump to `0.69.1` |\n| `docker-image.yml` | `docker build . --file Dockerfile` — no `Dockerfile` at repo root | Point to `apps/api/Dockerfile` |\n| `nextjs.yml` | Pages not enabled → `configure-pages` fails with \"Get Pages site failed\" | Add `enablement: true` so the action enables Pages automatically |"