### PR TITLE
fix(ci): pin actionlint to v1.7.11

### DIFF
--- a/.github/workflows/ghostvm-ai-workflow-lint.yml
+++ b/.github/workflows/ghostvm-ai-workflow-lint.yml
@@ -35,4 +35,4 @@ jobs:
           PY
 
       - name: Run actionlint
-        uses: rhysd/actionlint@v1
+        uses: rhysd/actionlint@v1.7.11


### PR DESCRIPTION
The `rhysd/actionlint@v1` tag does not exist — only versioned tags like `v1.7.11` are published. Pins to latest release.\n\nAlso: GitHub Pages has been enabled on the repo (`build_type: workflow`) so the Next.js deploy workflow will now pass.