### PR TITLE
fix(ci): install pyyaml before yaml validation step

### DIFF
--- a/.github/workflows/ghostvm-ai-workflow-lint.yml
+++ b/.github/workflows/ghostvm-ai-workflow-lint.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install PyYAML
+        run: pip install pyyaml
+
       - name: Validate YAML syntax
         run: |
           python - <<'PY'


### PR DESCRIPTION
The `Validate YAML syntax` step uses `import yaml` but `pyyaml` is not pre-installed on the GitHub Actions runner. Adds an explicit `pip install pyyaml` step before the validation.